### PR TITLE
Update Rake and setup code to operate the same as it does in the episode

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GEM
       bundler
     motion-kit (0.17.0)
       dbt (~> 1.1.5)
-    rake (10.4.2)
+    rake (12.3.1)
     sugarcube (3.2.0)
 
 PLATFORMS
@@ -19,3 +19,6 @@ DEPENDENCIES
   motion-kit
   rake
   sugarcube
+
+BUNDLED WITH
+   1.16.2

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
+
 require 'motion/project/template/ios'
 
 begin

--- a/app/screens/show_task_screen.rb
+++ b/app/screens/show_task_screen.rb
@@ -1,16 +1,18 @@
 class ShowTaskScreen < PM::Screen
-  attr_accessor :task
+  title 'Show Tasks'
 
-  def on_load
-    self.title = task.title
-
-    @layout = TaskLayout.new(root: self.view)
-    @layout.build
-    @layout.get(:notes).text = task.notes
-  end
-
-  def updateViewConstraints
-    @layout.add_top_layout_guide_constraint(self)
-    super
-  end
+  # attr_accessor :task
+  #
+  # def on_load
+  #   self.title = task.title
+  #
+  #   @layout = TaskLayout.new(root: self.view)
+  #   @layout.build
+  #   @layout.get(:notes).text = task.notes
+  # end
+  #
+  # def updateViewConstraints
+  #   @layout.add_top_layout_guide_constraint(self)
+  #   super
+  # end
 end


### PR DESCRIPTION
This source code was the completed code for both part 1 and 2. When you just `rake` it from the start, the app crashes when you select a table cell. But if you comment out the code in that file and just add `title “Show Task”` like he does at 15:37, the app works like it is supposed to at the end of the episode.